### PR TITLE
Add codeQL workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '15:00'
+      timezone: 'UTC'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: 43 6 * * 3
+  workflow_dispatch: null
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    concurrency: ${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - ruby
+    steps:
+      - name: Run Code Scanning
+        uses: department-of-veterans-affairs/codeql-tools/codeql-analysis@main
+        with:
+          language: ${{ matrix.language }}


### PR DESCRIPTION
Add codeQL workflow so the `veterans-affairs-code-scanning` bot will stop[ spamming us](https://github.com/department-of-veterans-affairs/sign-in-service-rb/issues?q=is%3Aissue+author%3Aveterans-affairs-code-scanning) even though CodeQL is already enabled. 

Replaces:
- https://github.com/department-of-veterans-affairs/sign-in-service-rb/pull/1