### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: 'bundler'
+  - package-ecosystem: bundler
     directory: '/'
     schedule:
-      interval: 'daily'
-      time: '15:00'
-      timezone: 'UTC'
+      interval: daily
+      time: '09:00'
+      timezone: America/New_York
+    groups:
+      patch-and-minor:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Group `patch` and `minor` updates for all gems excluding `rails` in a single PR. 
- major updates will continue to be in individual PRs